### PR TITLE
Fix mute state of the injection card

### DIFF
--- a/src/stores/calls/private-call/reducer.ts
+++ b/src/stores/calls/private-call/reducer.ts
@@ -7,6 +7,7 @@ import {
   CallContext,
   CallState,
   CallStreamKey,
+  InjectionStream,
   KeyLength,
   NewCall,
   NewInjectionStream,
@@ -28,6 +29,7 @@ export type PrivateCallState = {
   newCall: null | NewCall;
   newStream: null | NewStream;
   newInjectionStream: null | NewInjectionStream;
+  activeInjectionMute: boolean;
   activeCallsLoading: boolean;
   activeCallsError: null | string;
 } & PollingSettings;
@@ -44,6 +46,7 @@ export const INITIAL_STATE: PrivateCallState = {
   activeCallsLoading: false,
   activeCallsError: null,
   isPollingEnabled: false,
+  activeInjectionMute: false,
   pollingTime: PRODUCER_DEFAULT_POLLING_TIME,
 };
 
@@ -288,6 +291,34 @@ export const callsReducer: Reducer = baseReducer(INITIAL_STATE, {
       activeCall: updated,
     };
   },
+  [PrivateCallsActions.REQUEST_MUTE_BOT_FINISHED](
+    state: PrivateCallState,
+    action: PrivateCallsActions.RequestMuteBotFinished
+  ): PrivateCallState {
+    const call = state.activeCall;
+    if (!call) {
+      return state;
+    }
+
+    return {
+      ...state,
+      activeInjectionMute: true,
+    };
+  },
+  [PrivateCallsActions.REQUEST_UNMUTE_BOT_FINISHED](
+    state: PrivateCallState,
+    action: PrivateCallsActions.RequestUnmuteBotFinished
+  ): PrivateCallState {
+    const call = state.activeCall;
+    if (!call) {
+      return state;
+    }
+
+    return {
+      ...state,
+      activeInjectionMute: false,
+    };
+  },
 });
 
 const defaultCallValues = {
@@ -304,11 +335,14 @@ const fillDefaults = (
   defaultLatency: defaults.defaultLatency ?? defaultCallValues.defaultLatency,
   defaultPassphrase:
     defaults.defaultPassphrase ?? defaultCallValues.defaultPassphrase,
-  defaultKeyLength: defaults.defaultKeyLength ?? defaultCallValues.defaultKeyLength,
+  defaultKeyLength:
+    defaults.defaultKeyLength ?? defaultCallValues.defaultKeyLength,
   defaultProtocol: defaults.defaultProtocol ?? StreamProtocol.RTMP,
   defaultMode: defaults.defaultMode ?? StreamMode.Listener,
-  streams: call.streams ? call.streams.map((o) => ({
-    ...o,
-    audioSharing: o.type !== StreamType.VbSS,
-  })):[],
+  streams: call.streams
+    ? call.streams.map((o) => ({
+        ...o,
+        audioSharing: o.type !== StreamType.VbSS,
+      }))
+    : [],
 });

--- a/src/stores/calls/private-call/reducer.ts
+++ b/src/stores/calls/private-call/reducer.ts
@@ -29,7 +29,7 @@ export type PrivateCallState = {
   newCall: null | NewCall;
   newStream: null | NewStream;
   newInjectionStream: null | NewInjectionStream;
-  activeInjectionMute: boolean;
+  isBotMuted: boolean;
   activeCallsLoading: boolean;
   activeCallsError: null | string;
 } & PollingSettings;
@@ -46,7 +46,7 @@ export const INITIAL_STATE: PrivateCallState = {
   activeCallsLoading: false,
   activeCallsError: null,
   isPollingEnabled: false,
-  activeInjectionMute: false,
+  isBotMuted: false,
   pollingTime: PRODUCER_DEFAULT_POLLING_TIME,
 };
 
@@ -302,7 +302,7 @@ export const callsReducer: Reducer = baseReducer(INITIAL_STATE, {
 
     return {
       ...state,
-      activeInjectionMute: true,
+      isBotMuted: true,
     };
   },
   [PrivateCallsActions.REQUEST_UNMUTE_BOT_FINISHED](
@@ -316,7 +316,7 @@ export const callsReducer: Reducer = baseReducer(INITIAL_STATE, {
 
     return {
       ...state,
-      activeInjectionMute: false,
+      isBotMuted: false,
     };
   },
 });

--- a/src/stores/calls/selectors.ts
+++ b/src/stores/calls/selectors.ts
@@ -12,7 +12,7 @@ export const selectCallDetailsProps = createSelector((state: AppState)=> state.p
 _selectCallDetailsProps);
 
 function _selectCallDetailsProps(callState: PrivateCallState, contextState: TeamsContextState ): CallDetailsProps{
- const { activeCall: call, newStream, newInjectionStream, isPollingEnabled, pollingTime} = callState;
+ const { activeCall: call, newStream, newInjectionStream, isPollingEnabled, pollingTime, isBotMuted} = callState;
  const meetingId = contextState.values?.meetingId || '';
 
  if(!call){
@@ -30,7 +30,8 @@ function _selectCallDetailsProps(callState: PrivateCallState, contextState: Team
     isPollingEnabled,
     pollingTime,
     meetingId,
-    callProtocol: 0
+    callProtocol: 0,
+    isBotMuted: false
    }
  }
 
@@ -57,6 +58,7 @@ function _selectCallDetailsProps(callState: PrivateCallState, contextState: Team
   ),
   activeStreams: call.streams.filter((o) => ActiveStatuses.includes(o.state)),
   injectionStream: call.injectionStream,
-  callProtocol: call.defaultProtocol
+  callProtocol: call.defaultProtocol,
+  isBotMuted: isBotMuted
  }
 }

--- a/src/views/producer/call-details/CallDetails.tsx
+++ b/src/views/producer/call-details/CallDetails.tsx
@@ -36,6 +36,7 @@ const CallDetails: React.FC = () => {
     pollingTime,
     meetingId,
     callProtocol,
+    isBotMuted
   } = callDetailsProps;
 
   useInterval(
@@ -107,6 +108,7 @@ const CallDetails: React.FC = () => {
                           key={"injection-stream"}
                           callId={callId}
                           stream={injectionStream}
+                          isBotMuted={isBotMuted}
                         />
                       ),
                       key: `content-${"Injection Stream"}`,

--- a/src/views/producer/call-details/components/InjectionStreamCard.tsx
+++ b/src/views/producer/call-details/components/InjectionStreamCard.tsx
@@ -33,36 +33,30 @@ import {
   unmuteBotAsync,
 } from "@/stores/calls/private-call/asyncActions";
 import { openNewInjectionStreamSettings } from "@/stores/calls/private-call/actions/newInjectionStreamSettings";
-import AppState from "@/stores/AppState";
 
 interface InjectionCardProps {
   stream: InjectionStream | null;
   callId: string;
+  isBotMuted: boolean;
 }
 
 const OBFUSCATION_PATTERN = "********";
 
 const InjectionStreamCard: React.FC<InjectionCardProps> = (props) => {
   const dispatch = useDispatch();
-  const activeMute = useSelector(
-    (state: AppState) => state.privateCall.activeInjectionMute
-  );
-  const { stream, callId } = props;
+  const { stream, callId, isBotMuted } = props;
 
   const [expanded, setExpanded] = useState(false);
   const toggleExpanded = () => setExpanded(!expanded);
   const [showPassphrase, setShowPassphrase] = useState(false);
   const toggleShowPassphrase = () => setShowPassphrase(!showPassphrase);
-  const [botMuted, setBotMuted] = useState(activeMute ?? false);
 
   const muteBotAudio = () => {
     dispatch(muteBotAsync(callId));
-    setBotMuted(true);
   };
 
   const unmuteBotAudio = () => {
     dispatch(unmuteBotAsync(callId));
-    setBotMuted(false);
   };
 
   const toggleStreamOperation = () => {
@@ -138,7 +132,7 @@ const InjectionStreamCard: React.FC<InjectionCardProps> = (props) => {
           </Flex>
 
           <Flex vAlign="center" gap="gap.smaller">
-            {botMuted && (
+            {isBotMuted && (
               <Button
                 circular
                 icon={<MicOffIcon />}
@@ -146,7 +140,7 @@ const InjectionStreamCard: React.FC<InjectionCardProps> = (props) => {
                 onClick={unmuteBotAudio}
               />
             )}
-            {!botMuted && (
+            {!isBotMuted && (
               <Button
                 circular
                 icon={<MicIcon />}
@@ -199,10 +193,10 @@ const InjectionStreamCard: React.FC<InjectionCardProps> = (props) => {
 
           <Flex column hAlign="start" gap="gap.smaller">
             <Button
-              onClick={botMuted ? unmuteBotAudio : muteBotAudio}
+              onClick={isBotMuted ? unmuteBotAudio : muteBotAudio}
               style={{ minWidth: "115px" }}
             >
-              {botMuted ? (
+              {isBotMuted ? (
                 <MicOffIcon
                   style={{
                     marginRight: "0.25rem",
@@ -215,7 +209,7 @@ const InjectionStreamCard: React.FC<InjectionCardProps> = (props) => {
                   }}
                 />
               )}
-              <Text content={!botMuted ? "Mute" : "Unmute"} />
+              <Text content={!isBotMuted ? "Mute" : "Unmute"} />
             </Button>
             <Button
               onClick={toggleStreamOperation}

--- a/src/views/producer/call-details/components/InjectionStreamCard.tsx
+++ b/src/views/producer/call-details/components/InjectionStreamCard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 
 import {

--- a/src/views/producer/call-details/components/InjectionStreamCard.tsx
+++ b/src/views/producer/call-details/components/InjectionStreamCard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import React, { useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 
 import {
@@ -33,6 +33,7 @@ import {
   unmuteBotAsync,
 } from "@/stores/calls/private-call/asyncActions";
 import { openNewInjectionStreamSettings } from "@/stores/calls/private-call/actions/newInjectionStreamSettings";
+import AppState from "@/stores/AppState";
 
 interface InjectionCardProps {
   stream: InjectionStream | null;
@@ -43,14 +44,16 @@ const OBFUSCATION_PATTERN = "********";
 
 const InjectionStreamCard: React.FC<InjectionCardProps> = (props) => {
   const dispatch = useDispatch();
-
+  const activeMute = useSelector(
+    (state: AppState) => state.privateCall.activeInjectionMute
+  );
   const { stream, callId } = props;
 
   const [expanded, setExpanded] = useState(false);
   const toggleExpanded = () => setExpanded(!expanded);
   const [showPassphrase, setShowPassphrase] = useState(false);
   const toggleShowPassphrase = () => setShowPassphrase(!showPassphrase);
-  const [botMuted, setBotMuted] = useState(false);
+  const [botMuted, setBotMuted] = useState(activeMute ?? false);
 
   const muteBotAudio = () => {
     dispatch(muteBotAsync(callId));
@@ -98,7 +101,10 @@ const InjectionStreamCard: React.FC<InjectionCardProps> = (props) => {
 
   const getInjectionUrl = (stream: InjectionStream): string => {
     if (stream.protocol === StreamProtocol.RTMP && stream.injectionUrl) {
-      return stream.injectionUrl.replace(stream.passphrase, OBFUSCATION_PATTERN);
+      return stream.injectionUrl.replace(
+        stream.passphrase,
+        OBFUSCATION_PATTERN
+      );
     }
 
     return stream.injectionUrl ?? "";
@@ -240,7 +246,7 @@ const InjectionStreamCard: React.FC<InjectionCardProps> = (props) => {
 
               <Text weight="bold" content="Stream URL:" />
 
-              <Text style={{overflowWrap: 'break-word'}}>
+              <Text style={{ overflowWrap: "break-word" }}>
                 {injectionUrl}{" "}
                 <Button circular iconOnly>
                   <CopyToClipboard text={stream?.injectionUrl}>

--- a/src/views/producer/call-details/types.ts
+++ b/src/views/producer/call-details/types.ts
@@ -17,4 +17,5 @@ export interface CallDetailsProps {
   pollingTime: number;
   meetingId: string;
   callProtocol: StreamProtocol;
+  isBotMuted: boolean;
 }


### PR DESCRIPTION
Fixed the mute status of the Teams Meeting extension injection card as the status was not saved when switching views.